### PR TITLE
Add admin auth and fullscreen enhancements

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import argparse
 # DON\'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -9,8 +10,20 @@ from flask_cors import CORS
 from src.models.evaluation import db
 from src.routes.evaluation import evaluation_bp
 
+DEFAULT_ADMIN_PASSWORD = 'tiandatiankai2025'
+
+
+def resolve_admin_password():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--pwd', dest='admin_password')
+    args, remaining = parser.parse_known_args()
+    sys.argv = [sys.argv[0], *remaining]
+    return args.admin_password or DEFAULT_ADMIN_PASSWORD
+
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = 'evaluation_system_secret_key_2024'
+app.config['ADMIN_USERNAME'] = 'super'
+app.config['ADMIN_PASSWORD'] = resolve_admin_password()
 
 # 启用CORS
 CORS(app, origins="*")

--- a/backend/src/static/index.html
+++ b/backend/src/static/index.html
@@ -26,48 +26,50 @@
 
         <!-- 大屏展示页面 -->
         <div id="displayPage" class="page active">
-            <!-- 小组切换按钮 -->
-            <div class="group-tabs">
-                <div id="groupTabs" class="tabs-container"></div>
-            </div>
-
-            <!-- 主要内容区域 -->
-            <div class="main-content">
-                <!-- 左侧：小组成员 -->
-                <div class="left-panel">
-                    <h3>小组成员</h3>
-                    <div id="membersList" class="members-list"></div>
+            <div class="display-stage">
+                <!-- 小组切换按钮 -->
+                <div class="group-tabs">
+                    <div id="groupTabs" class="tabs-container"></div>
                 </div>
 
-                <!-- 中间：小组信息和投票统计 -->
-                <div class="center-panel">
-                    <div class="group-header">
-                        <img id="groupLogo" class="group-logo" src="" alt="小组Logo">
-                        <h2 id="groupName" class="group-name">请选择小组</h2>
+                <!-- 主要内容区域 -->
+                <div class="main-content">
+                    <!-- 左侧：小组成员 -->
+                    <div class="left-panel">
+                        <h3>小组成员</h3>
+                        <div id="membersList" class="members-list"></div>
                     </div>
-                    
-                    <div class="vote-stats">
-                        <div class="stat-item score">
-                            <div class="stat-icon">🏆</div>
-                            <div class="stat-number" id="totalScore">0</div>
-                            <div class="stat-label">投票计分</div>
+
+                    <!-- 中间：小组信息和投票统计 -->
+                    <div class="center-panel">
+                        <div class="group-header">
+                            <img id="groupLogo" class="group-logo" src="" alt="小组Logo">
+                            <h2 id="groupName" class="group-name">请选择小组</h2>
+                        </div>
+
+                        <div class="vote-stats">
+                            <div class="stat-item score">
+                                <div class="stat-icon">🏆</div>
+                                <div class="stat-number" id="totalScore">0</div>
+                                <div class="stat-label">投票计分</div>
+                            </div>
+                        </div>
+
+                        <div class="action-section">
+                            <button id="openMobileBtn" class="btn btn-primary">进入评价页面</button>
+                            <p class="share-text">复制链接访问评价页：<a id="evaluationShareLink" class="share-link" href="#" target="_blank" rel="noopener">请选择小组</a></p>
                         </div>
                     </div>
 
-                    <div class="action-section">
-                        <button id="openMobileBtn" class="btn btn-primary">进入评价页面</button>
-                        <p class="share-text">复制链接访问评价页：<a id="evaluationShareLink" class="share-link" href="#" target="_blank" rel="noopener">请选择小组</a></p>
-                    </div>
-                </div>
-
-                <!-- 右侧：照片轮播 -->
-                <div class="right-panel">
-                    <h3>小组风采</h3>
-                    <div id="photoCarousel" class="photo-carousel">
-                        <div class="carousel-container">
-                            <div id="photoSlides" class="photo-slides"></div>
+                    <!-- 右侧：照片轮播 -->
+                    <div class="right-panel">
+                        <h3>小组风采</h3>
+                        <div id="photoCarousel" class="photo-carousel">
+                            <div class="carousel-container">
+                                <div id="photoSlides" class="photo-slides"></div>
+                            </div>
+                            <div class="carousel-dots" id="carouselDots"></div>
                         </div>
-                        <div class="carousel-dots" id="carouselDots"></div>
                     </div>
                 </div>
             </div>
@@ -145,6 +147,30 @@
             <div class="ranking-container">
                 <h2 class="ranking-title">最终排名</h2>
                 <div id="rankingDisplay" class="ranking-display"></div>
+            </div>
+        </div>
+
+        <!-- 管理员登录 -->
+        <div id="adminLoginModal" class="admin-login-modal" role="dialog" aria-modal="true" aria-labelledby="adminLoginTitle" aria-hidden="true">
+            <div class="admin-login-dialog">
+                <button type="button" id="adminLoginCloseBtn" class="admin-login-close" aria-label="关闭">✕</button>
+                <h3 id="adminLoginTitle">管理员登录</h3>
+                <p class="admin-login-description">请输入超级管理员密码以进入后台管理。</p>
+                <form id="adminLoginForm" class="admin-login-form">
+                    <div class="form-group">
+                        <label for="adminUsername">账号</label>
+                        <input type="text" id="adminUsername" value="super" autocomplete="username" readonly>
+                    </div>
+                    <div class="form-group">
+                        <label for="adminPassword">密码</label>
+                        <input type="password" id="adminPassword" placeholder="请输入管理员密码" autocomplete="current-password" required>
+                    </div>
+                    <div id="adminLoginError" class="admin-login-error" role="alert"></div>
+                    <div class="form-actions">
+                        <button type="submit">登录</button>
+                        <button type="button" id="adminLoginCancelBtn">取消</button>
+                    </div>
+                </form>
             </div>
         </div>
 

--- a/backend/src/static/styles.css
+++ b/backend/src/static/styles.css
@@ -67,6 +67,79 @@ body {
     color: #FFD700;
 }
 
+/* 管理员登录模态框 */
+.admin-login-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2100;
+    backdrop-filter: blur(4px);
+    padding: 1.5rem;
+}
+
+.admin-login-modal.active {
+    display: flex;
+}
+
+.admin-login-dialog {
+    width: 100%;
+    max-width: 420px;
+    background: linear-gradient(135deg, rgba(10, 46, 93, 0.95), rgba(0, 31, 63, 0.95));
+    border: 1px solid rgba(255, 215, 0, 0.6);
+    border-radius: 18px;
+    padding: 2rem;
+    position: relative;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.admin-login-close {
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    background: transparent;
+    border: none;
+    color: #B0C4DE;
+    font-size: 1.4rem;
+    cursor: pointer;
+    transition: color 0.3s ease;
+}
+
+.admin-login-close:hover {
+    color: #FFD700;
+}
+
+.admin-login-description {
+    color: #B0C4DE;
+    margin-bottom: 1.2rem;
+    font-size: 0.95rem;
+}
+
+.admin-login-form .form-group label {
+    color: #FFD700;
+}
+
+.admin-login-form input[type="password"] {
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.admin-login-error {
+    min-height: 1.2rem;
+    color: #FF6B6B;
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.admin-login-form .form-actions {
+    justify-content: flex-end;
+}
+
+.admin-login-form .form-actions button {
+    min-width: 100px;
+}
+
 /* 表单样式 */
 .form-group {
     margin-bottom: 1.5rem;
@@ -771,7 +844,7 @@ body {
 .ranking-display {
     display: flex;
     justify-content: center;
-    align-items: end;
+    align-items: flex-end;
     gap: 2rem;
     min-height: 400px;
     flex-wrap: wrap;
@@ -780,13 +853,16 @@ body {
 .ranking-item {
     background: rgba(255, 255, 255, 0.1);
     border-radius: 20px;
-    padding: 2rem 1.5rem;
+    padding: 2rem 1.5rem 2.5rem;
     backdrop-filter: blur(10px);
     border: 2px solid rgba(255, 255, 255, 0.2);
     text-align: center;
     transition: all 0.3s ease;
     position: relative;
-    min-width: 180px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .ranking-item:hover {
@@ -841,22 +917,45 @@ body {
     font-size: 2rem;
 }
 
+.ranking-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+}
+
 .ranking-name {
     font-size: 1.3rem;
     font-weight: bold;
-    margin-bottom: 1rem;
     word-break: break-all;
 }
 
 .ranking-score {
     font-size: 1.5rem;
     font-weight: bold;
-    margin-bottom: 0.5rem;
 }
 
 .ranking-position {
-    font-size: 1rem;
-    opacity: 0.8;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 0.4rem;
+    margin-top: auto;
+    font-size: 1.2rem;
+    font-weight: 600;
+    opacity: 0.9;
+}
+
+.ranking-position-number {
+    font-size: 2.6rem;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.ranking-position-prefix,
+.ranking-position-suffix {
+    font-size: 1.1rem;
+    font-weight: 600;
 }
 
 /* 手机端样式 */
@@ -1409,25 +1508,51 @@ body.fullscreen-mode .navbar {
 
 body.fullscreen-mode .page {
     min-height: 100vh;
-    padding-top: 2rem;
+    padding: 2rem 2rem 3rem;
 }
 
-body.fullscreen-mode #displayPage {
-    padding-bottom: 2rem;
+body.fullscreen-mode[data-fullscreen-page="displayPage"] #displayPage {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 0 3rem;
 }
 
-body.fullscreen-mode .group-tabs {
+body.fullscreen-mode[data-fullscreen-page="displayPage"] .display-stage {
+    max-width: none;
+}
+
+body.fullscreen-mode[data-fullscreen-page="displayPage"] .display-stage.scaled {
+    will-change: transform;
+}
+
+body.fullscreen-mode[data-fullscreen-page="displayPage"] .group-tabs {
     margin-bottom: 1.2rem;
 }
 
-body.fullscreen-mode .main-content {
-    max-width: 100%;
+body.fullscreen-mode[data-fullscreen-page="displayPage"] .display-stage .main-content {
+    max-width: none;
     width: 100%;
-    height: calc(100vh - 200px);
+    height: auto;
 }
 
-body.fullscreen-mode #displayPage .members-list {
+body.fullscreen-mode[data-fullscreen-page="displayPage"] #displayPage .members-list {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+body.fullscreen-mode[data-fullscreen-page="rankingPage"] #rankingPage {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+body.fullscreen-mode[data-fullscreen-page="rankingPage"] .ranking-title {
+    font-size: 3rem;
+}
+
+body.fullscreen-mode[data-fullscreen-page="rankingPage"] .ranking-display {
+    gap: 2.5rem;
 }
 
 .fullscreen-exit-btn {


### PR DESCRIPTION
## Summary
- add a configurable super admin login with token-protected management APIs
- redesign ranking cards and fullscreen behavior including responsive scaling on the display stage
- integrate an admin login modal and ensure authenticated requests from the frontend

## Testing
- python -m compileall backend/src

------
https://chatgpt.com/codex/tasks/task_e_68d50c93b1148320b0a8f33c4e733489