### PR TITLE
Improve Debian mirror handling in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,34 @@
 FROM python:3.11-slim
 
 ARG DEBIAN_MIRROR=mirrors.aliyun.com
+ARG DEBIAN_MIRROR_SCHEME=https
 ARG PIP_INDEX=https://mirrors.aliyun.com/pypi/simple
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_INDEX_URL=${PIP_INDEX}
 
-# 1) 把 deb 源换成国内镜像（同时替换 security 源）
-RUN sed -i -e "s|deb.debian.org|${DEBIAN_MIRROR}|g" \
-           -e "s|security.debian.org|${DEBIAN_MIRROR}|g" /etc/apt/sources.list \
- && apt-get -o Acquire::Retries=3 update \
- && apt-get -y --no-install-recommends install build-essential gcc curl ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+# 1) 尝试使用国内镜像，如果失败则回退到官方源
+RUN set -eux; \
+    cp /etc/apt/sources.list /tmp/sources.list.default; \
+    . /etc/os-release; \
+    MIRROR_HOST="${DEBIAN_MIRROR}"; \
+    MIRROR_SCHEME="${DEBIAN_MIRROR_SCHEME}"; \
+    if [ -n "${MIRROR_HOST}" ]; then \
+        cat > /etc/apt/sources.list <<EOF
+deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME} main
+deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME}-updates main
+deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME}-backports main
+deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian-security ${VERSION_CODENAME}-security main
+EOF
+    fi; \
+    if ! apt-get -o Acquire::Retries=3 update; then \
+        echo "Mirror ${MIRROR_HOST} unavailable, falling back to default Debian sources"; \
+        cp /tmp/sources.list.default /etc/apt/sources.list; \
+        apt-get -o Acquire::Retries=3 update; \
+    fi; \
+    rm -f /tmp/sources.list.default; \
+    apt-get -y --no-install-recommends install build-essential curl ca-certificates libgfortran5 libgomp1; \
+    rm -rf /var/lib/apt/lists/*
 
 # 2) 固化 pip 源（也可只用上面的 ENV）
 RUN mkdir -p /etc/pip.conf.d \
@@ -24,10 +41,7 @@ WORKDIR /app
 
 COPY backend/requirements.txt ./backend/requirements.txt
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libgfortran5 libgomp1 \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
 
 COPY backend ./backend
 


### PR DESCRIPTION
## Summary
- add configurable scheme and fallback logic when switching Debian mirrors
guring image build
- consolidate apt package installation while keeping pip mirror configuration

## Testing
- not run (network-dependent Docker build)

------
https://chatgpt.com/codex/tasks/task_e_68da501358048320a1d3ec6d2b0d66ce