### PR TITLE
Fix Dockerfile heredoc indentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
     MIRROR_HOST="${DEBIAN_MIRROR}"; \
     MIRROR_SCHEME="${DEBIAN_MIRROR_SCHEME}"; \
     if [ -n "${MIRROR_HOST}" ]; then \
-        cat > /etc/apt/sources.list <<EOF
+        cat <<'EOF' > /etc/apt/sources.list
 deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME} main
 deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME}-updates main
 deb ${MIRROR_SCHEME}://${MIRROR_HOST}/debian ${VERSION_CODENAME}-backports main


### PR DESCRIPTION
## Summary
- update the Dockerfile heredoc to use a non-indented EOF marker so Docker can parse the RUN instruction correctly

## Testing
- not run (docker unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da5fc3af008320b832c61f08d3befe