### PR TITLE
Generate QR codes server-side

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,10 @@ Flask-SocketIO==5.3.6
 python-socketio==5.8.0
 python-engineio==4.7.1
 
+# 二维码生成
+Pillow==10.4.0
+qrcode==7.4.2
+
 # Excel处理依赖
 openpyxl==3.1.2
 pandas==1.5.3

--- a/backend/src/static/index.html
+++ b/backend/src/static/index.html
@@ -245,7 +245,6 @@
     <!-- 隐藏的文件上传input -->
     <input type="file" id="fileInput" accept=".xlsx,.xls" style="display: none;">
 
-    <script src="qrcode.min.js"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a backend endpoint that renders the mobile evaluation link as a QR code image
- update the dashboard frontend to load QR codes from the new API instead of the qrcode.js library
- include Pillow and qrcode dependencies for server-side QR generation

## Testing
- python -m compileall backend/src

------
https://chatgpt.com/codex/tasks/task_e_68da791b37f8832084587d4a61968ea2