### PR TITLE
Style admin login inputs

### DIFF
--- a/backend/src/static/app.js
+++ b/backend/src/static/app.js
@@ -123,6 +123,7 @@ function showAdminLoginModal() {
 
     if (passwordInput) {
         passwordInput.value = '';
+        passwordInput.classList.remove('has-value');
         passwordInput.focus();
     }
 
@@ -456,6 +457,7 @@ function setupEventListeners() {
     const adminLoginForm = document.getElementById('adminLoginForm');
     if (adminLoginForm) {
         adminLoginForm.addEventListener('submit', handleAdminLoginSubmit);
+        initializeAdminLoginInputStyles(adminLoginForm);
     }
 
     const adminLoginModal = document.getElementById('adminLoginModal');
@@ -479,6 +481,23 @@ function setupEventListeners() {
 
     // 后台管理按钮事件绑定
     setupAdminButtonEvents();
+}
+
+function initializeAdminLoginInputStyles(form) {
+    const loginInputs = form.querySelectorAll('input');
+    loginInputs.forEach((input) => {
+        const toggleValueClass = () => {
+            if (input.value && input.value.trim() !== '') {
+                input.classList.add('has-value');
+            } else {
+                input.classList.remove('has-value');
+            }
+        };
+
+        toggleValueClass();
+        input.addEventListener('input', toggleValueClass);
+        input.addEventListener('blur', toggleValueClass);
+    });
 }
 
 function prepareFullscreenTargetPage() {

--- a/backend/src/static/styles.css
+++ b/backend/src/static/styles.css
@@ -165,6 +165,11 @@ body {
     transition: all 0.3s ease;
 }
 
+.admin-login-form input.has-value {
+    color: #000000;
+    font-weight: 600;
+}
+
 .form-helper {
     color: #B0C4DE;
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add runtime styling to highlight admin login inputs when they contain text
- ensure the admin password field clears its styling when the modal reopens
- apply bold black typography to populated admin login fields via CSS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da81c820d4832098df6845c9256028